### PR TITLE
Move stream position to the start to prevent empty log entry context

### DIFF
--- a/src/Lykke.Common.ApiLibrary/Middleware/GlobalErrorHandlerMiddleware.cs
+++ b/src/Lykke.Common.ApiLibrary/Middleware/GlobalErrorHandlerMiddleware.cs
@@ -39,6 +39,12 @@ namespace Lykke.Common.ApiLibrary.Middleware
 
         private async Task LogError(HttpContext context, Exception ex)
         {
+            // request body might be already read at the moment 
+            if (context.Request.Body.CanSeek)
+            {
+                context.Request.Body.Seek(0, SeekOrigin.Begin);
+            }
+
             using (var ms = new MemoryStream())
             {
                 context.Request.Body.CopyTo(ms);


### PR DESCRIPTION
If exception is thrown within controller action then body is already read and body stream position points to the end of stream and CopyTo() method does nothing.