### PR TITLE
Missed log message issue has been fixed

### DIFF
--- a/src/Lykke.Common.ApiLibrary/Middleware/ClientErrorHandlerMiddleware.cs
+++ b/src/Lykke.Common.ApiLibrary/Middleware/ClientErrorHandlerMiddleware.cs
@@ -66,7 +66,7 @@ namespace Lykke.Common.ApiLibrary.Middleware
                     statusCode = context.Response.StatusCode,
                     body = body
                 },
-                "");
+                "Client request error");
         }
     }
 }


### PR DESCRIPTION
This PR fixes errors like this:

```
Message: System.ArgumentException: Either message or exception should be specified at least
   at Lykke.Common.Log.MicrosoftLoggingBasedLogExtensions.Log(ILog log, LogLevel logLevel, String callerFilePath, String process, Int32 callerLineNumber, String message, Object context, Exception exception, Nullable`1 moment)
   at Lykke.Common.Log.MicrosoftLoggingBasedLogExtensions.Warning(ILog log, String process, String message, Exception exception, Object context, Nullable`1 moment, String callerFilePath, Int32 callerLineNumber)
   at Lykke.Logs.Log.Common.Log.ILog.WriteWarningAsync(String process, String context, String info, Nullable`1 dateTime)
   at Common.Log.LogExtensions.WriteWarning(ILog log, String process, Object context, String info, Nullable`1 dateTime)
   at async Lykke.Common.ApiLibrary.Middleware.ClientErrorHandlerMiddleware.LogError(?)
   at async Lykke.Common.ApiLibrary.Middleware.ClientErrorHandlerMiddleware.Invoke(?)
   at async Lykke.Common.ApiLibrary.Middleware.GlobalErrorHandlerMiddleware.Invoke(?)
```